### PR TITLE
Update segment proposal language to be more agency-friendly

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ def generate_custom_segment_proposals(signal_spec: str, existing_segments: List[
     For each proposal, consider:
     - What specific contextual signals could be used
     - What makes this segment unique from existing ones
-    - Why an advertiser would pay a premium for this targeting
+    - How this targeting delivers value through precision and relevance
     
     Return your response as a JSON array:
     [
@@ -131,11 +131,11 @@ def generate_custom_segment_proposals(signal_spec: str, existing_segments: List[
         "target_signals": "What signals this captures (audiences, contexts, behaviors)",
         "estimated_coverage_percentage": 2.5,
         "estimated_cpm": 6.50,
-        "creation_rationale": "Why this segment would be valuable and what signals would be used"
+        "creation_rationale": "How this segment enables precise targeting and what signals would be used"
       }}
     ]
     
-    Focus on high-value, specific segments that would command premium pricing.
+    Focus on specific, impactful segments that deliver measurable results.
     """
     
     try:


### PR DESCRIPTION
## Summary
- Updated AI prompt language to focus on value and effectiveness rather than premium pricing
- Changed "pay a premium" to "delivers value through precision and relevance"
- Emphasizes measurable results instead of higher costs

## Context
An agency raised concerns that language like "Advertisers would pay a premium" immediately makes them think "this is going to be expensive and blow out my CPMs." This PR updates the language to be more agency-friendly by focusing on the strategic benefits and effectiveness of targeting options.

## Changes
- Modified segment proposal prompts in `main.py:121-138`
- Replaced pricing-focused language with value-focused messaging
- Updated creation rationale to emphasize precision targeting

## Test plan
- [ ] Generate new segment proposals and verify they use value-focused language
- [ ] Confirm proposals no longer mention premium pricing
- [ ] Test that segment functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)